### PR TITLE
Include newline character to prevent leaving empty lines.

### DIFF
--- a/tasks/stripcomments.js
+++ b/tasks/stripcomments.js
@@ -15,8 +15,8 @@ module.exports = function(grunt) {
 
   grunt.registerMultiTask('comments', 'Remove comments from production code', function() {
 
-    var multilineComment = /\/\*[\s\S]*?\*\//g;
-    var singleLineComment = /\/\/.*/g;
+    var multilineComment = /\/\*[^!][\s\S]*?\*\/\n/g;
+    var singleLineComment = /\/\/.*\n/g;
 
     var options = this.options({
       singleline: true,


### PR DESCRIPTION
Added newline in regexp.
Not removing special comments: /*! I am a special comment */
